### PR TITLE
Flutter Documentation

### DIFF
--- a/flutter/flutter-integration.mdx
+++ b/flutter/flutter-integration.mdx
@@ -1,8 +1,0 @@
----
-sidebarTitle: 'Flutter Integration'
-title: 'Flutter Integration'
-icon: rocket
----
-
-Here you will see how to implement the Mellowtel library in your Flutter application.
-Estimated time to complete: 5-7 minutes.

--- a/flutter/setup.mdx
+++ b/flutter/setup.mdx
@@ -4,7 +4,7 @@ title: 'Flutter Integration'
 icon: 'rocket'
 ---
 
-Mellowtel is currently supported for iOS, MacOs and Windows.
+Mellowtel is currently supported for iOS, MacOS and Windows.
 
 For the latest setup instructions for mellowtel, please refer the pub.dev (readme)[https://pub.dev/packages/mellowtel].
 

--- a/flutter/setup.mdx
+++ b/flutter/setup.mdx
@@ -6,6 +6,6 @@ icon: 'rocket'
 
 Mellowtel is currently supported for iOS, MacOS and Windows.
 
-For the latest setup instructions for mellowtel, please refer the pub.dev (readme)[https://pub.dev/packages/mellowtel].
+For the latest setup instructions for Mellowtel, please refer the pub.dev (readme)[https://pub.dev/packages/mellowtel].
 
 Estimated time to complete: 5-10 minutes.

--- a/flutter/setup.mdx
+++ b/flutter/setup.mdx
@@ -1,0 +1,11 @@
+---
+sidebarTitle: 'Setup'
+title: 'Flutter Integration'
+icon: 'rocket'
+---
+
+Mellowtel is currently supported for iOS, MacOs and Windows.
+
+For the latest setup instructions for mellowtel, please refer the pub.dev (readme)[https://pub.dev/packages/mellowtel].
+
+Estimated time to complete: 5-10 minutes.

--- a/flutter/submit-app.mdx
+++ b/flutter/submit-app.mdx
@@ -1,8 +1,0 @@
----
-sidebarTitle: 'Submit to the App Store'
-title: 'Submit to the App Store'
-icon: 'apple'
----
-
-After you are done following the instructions to import Mellowtel in your app that have been outlined in [flutter integration](https://docs.mellowtel.it/flutter/flutter-integration) you are ready to submit your app to the App Store.
-Estimated time to complete: 3-5 minutes.

--- a/flutter/user-consent.mdx
+++ b/flutter/user-consent.mdx
@@ -39,6 +39,12 @@ The consent dialog by default opens when the `start()` method is called if the u
 ```dart
 await mellowtel.start(
     ... // other configuration
+    onOptIn: () async {
+        // Enable the incentives if user has provided consent. 
+    }, 
+    onOptOut: () async {
+        // Disable the incentives if user has denied/revoked consent.
+    },
     showConsentDialog: true
 );
 ```
@@ -62,10 +68,10 @@ Use the `showConsentSettingsPage()` method to open the consent settings dialog.
 await mellowtel.showConsentSettingsPage(
     context,
     onOptIn: () async {
-    // Handle enabling services when consent is provided.
-    },
+        // Enable the incentives if user has provided consent. 
+    }, 
     onOptOut: () async {
-    // Handle disabling services if consent is denied.
+        // Disable the incentives if user has denied/revoked consent.
     },
 );
 ```

--- a/flutter/user-consent.mdx
+++ b/flutter/user-consent.mdx
@@ -1,0 +1,96 @@
+---
+title: 'User Consent'
+description: 'Users can decide at any time if they want to be part of the Mellowtel Network or not.'
+icon: 'toggle_on'
+---
+
+## Introduction
+
+In order to activate Mellowtel, users must give their explicit consent. The package provides a way to opt in or opt out. The core idea is that since it's their unused Internet bandwidth, they should decide if they want to share it or not.
+
+Users can provide their consent via a consent settings dialog.
+
+### Consent Dialog Configuration
+
+The consent dialog is a crucial part of the Mellowtel integration. It ensures that users are fully informed and provide explicit consent before sharing their unused internet bandwidth.
+
+You can define the consent dialog configuration when creating an instance of `Mellowtel`
+
+```dart
+import 'package:mellowtel/mellowtel.dart';
+
+final Mellowtel mellowtel = Mellowtel(
+    "your_configuration_key",
+    dialogConfiguration: const ConsentDialogConfiguration(
+        appName: 'Your App Name',
+        incentive: 'Earn rewards by sharing your unused internet'
+        appIcon: 'assets/logo.png', // Optional app icon displayed in the consent dialog. Helps build trust.
+        acceptButtonText: 'Yes, let's go!', // Optional Text for the accept button ("Yes" by default).
+        declineButtonText: 'Not now', // Optional Text for the decline button ("No" by default).
+        dialogTextOverride: 'Custom consent message', // Optional custom or localized consent dialog message.
+    ),
+);
+```
+
+#### Opening the consent Dialog
+
+The consent dialog by default opens when the `start()` method is called if the user has not provided their preference yet.
+
+```dart
+await mellowtel.start(
+    ... // other configuration
+    showConsentDialog: true
+);
+```
+
+You can set `showConsentDialog` to false if you'd like to manage where the dialog shows up. We recommend you to call `start` method at two different locations:
+
+1. **On App Launch** with `showConsentDialog: false` to begin operating if permission is already provided.
+2. **After First "Aha" Moment:** with `showConsentDialog: true` o request consent after users experience the app's value.
+
+This approach ensures Mellowtel starts operating immediately while obtaining user consent at an optimal time.
+
+### Consent Settings Dialog
+
+Mellowtel ensures full control and privacy for your users. Your users can change their consent at any time from the Consent Settings Page. You may provide it as an option within the settings page of your app.
+
+#### Show Consent Settings Page
+
+Use the `showConsentSettingsPage()` method to open the consent settings dialog.
+
+```dart
+await mellowtel.showConsentSettingsPage(
+    context,
+    onOptIn: () async {
+    // Handle enabling services when consent is provided.
+    },
+    onOptOut: () async {
+    // Handle disabling services if consent is denied.
+    },
+);
+```
+
+<img src="https://raw.githubusercontent.com/mellowtel-inc/mellowtel-flutter/main/assets/settings-popup.png" width="300px" />
+
+### Manual Methods (Not Recommended)
+
+In addition to the consent dialog and settings page, you can manually manage the user's consent using the `optIn()` and `optOut()` methods.
+
+#### Opt-In
+
+Manually mark the user as opted in.
+```dart
+await mellowtel.optIn();
+```
+#### Opt-Out
+
+Manually mark the user as opted out.
+```dart
+await mellowtel.optOut();
+```
+#### Check Consent Status
+
+You can check the user's current consent status using the `checkConsent()` method.
+```dart
+bool? hasOptedIn = await mellowtel.checkConsent();
+```

--- a/mint.json
+++ b/mint.json
@@ -57,8 +57,8 @@
     {
       "group": "Flutter",
       "pages": [
-        "flutter/flutter-integration",
-        "flutter/submit-app"
+        "flutter/setup",
+        "flutter/user-consent"
       ]
     },
     {


### PR DESCRIPTION
For the setup, we're redirecting user to the pub.dev readme since that will be the most upto date and accurate instruction set. 

We have added a section specifically focusing on User Consent that is not covered fully in the readme.